### PR TITLE
Update user table and add ballot table

### DIFF
--- a/api/src/migrations/1-user.js
+++ b/api/src/migrations/1-user.js
@@ -36,9 +36,9 @@ module.exports = {
         allowNull: true,
         type: Sequelize.TEXT
       },
-      meetUpAddress: {
+      step: {
         allowNull: true,
-        type: Sequelize.STRING
+        type: Sequelize.INTEGER
       }
     });
   },

--- a/api/src/migrations/4-ballots.js
+++ b/api/src/migrations/4-ballots.js
@@ -26,6 +26,26 @@ module.exports = {
       updatedAt: {
         allowNull: false,
         type: Sequelize.DATE
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        allowNull: true
+      },
+      corepresentative: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      ballotNumber: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      meetUpAddress: {
+        allowNull: true,
+        type: Sequelize.STRING
       }
     });
   },

--- a/api/src/modules/ballots/model.js
+++ b/api/src/modules/ballots/model.js
@@ -18,7 +18,22 @@ module.exports = function(sequelize, DataTypes) {
     updatedAt: {
       type: DataTypes.DATE
     },
+    userId: {
+      type: DataTypes.INTEGER
+    },
+    corepresentative: {
+      type: DataTypes.STRING
+    },
+    ballotNumber: {
+      type: DataTypes.INTEGER
+    },
+    meetUpAddress: {
+      type: DataTypes.STRING
+    }
   })
+  Ballot.associate = function(models) {
+    Ballot.belongsTo(models.User, { foreignKey: 'userId'} )
+  }
 
   return Ballot
 }

--- a/api/src/modules/ballots/mutations.js
+++ b/api/src/modules/ballots/mutations.js
@@ -25,6 +25,18 @@ export const ballotCreate = {
     subject: {
       name: 'subject',
       type: GraphQLString
+    },
+    userId: {
+      name: 'userId',
+      type: GraphQLInt
+    },
+    corepresentative: {
+      name: 'corepresentative',
+      type: GraphQLString
+    },
+    ballotNumber: {
+      name: 'ballotNumber',
+      type: GraphQLString
     }
   },
   resolve: create
@@ -48,6 +60,18 @@ export const ballotUpdate = {
     },
     subject: {
       name: 'subject',
+      type: GraphQLString
+    },
+    corepresentative: {
+      name: 'corepresentative',
+      type: GraphQLString
+    },
+    ballotNumber: {
+      name: 'ballotNumber',
+      type: GraphQLString
+    },
+    meetUpAddress: {
+      name: 'meetUpAddress',
       type: GraphQLString
     }
   },

--- a/api/src/modules/ballots/query.js
+++ b/api/src/modules/ballots/query.js
@@ -3,13 +3,20 @@ import { GraphQLInt, GraphQLString, GraphQLList } from 'graphql'
 
 //App Imports
 import { BallotType } from './types'
-import { getById } from './resolvers'
+import { getById, getAll} from './resolvers'
 
 // By ID
-export const ballots = {
+export const ballot = {
   type: BallotType,
   args: {
     id: { type: GraphQLInt }
   },
   resolve: getById
+}
+
+
+// Get All
+export const ballots = {
+  type: new GraphQLList(BallotType),
+  resolve: getAll
 }

--- a/api/src/modules/ballots/resolvers.js
+++ b/api/src/modules/ballots/resolvers.js
@@ -5,19 +5,25 @@ import serverConfig from '../../config/server'
 import models from '../../setup/models'
 
 // Create
-export async function create(parentValue, { type, description, subject }) {
+export async function create(parentValue, { type, description, subject, userId, corepresentative, ballotNumber }) {
   return await models.Ballot.create({
     type,
     description,
-    subject
+    subject,
+    userId,
+    corepresentative,
+    ballotNumber
   })
 }
 // Update
-export async function update(parentValue, { id ,type, description, subject}) {
+export async function update(parentValue, { id ,type, description, subject, corepresentative, ballotNumber, meetUpAddress}) {
   return await models.Ballot.update({
     type,
     description,
-    subject
+    subject,
+    corepresentative,
+    ballotNumber,
+    meetUpAddress
   }, {where: { id } } )
 }
 // Delete
@@ -28,6 +34,18 @@ export async function deleteBallot(parentValue, { id }) {
 // Get by ID
 export async function getById(parentValue, { id }) {
   return await models.Ballot.findOne({
-    where: { id }
+    where: { id },
+    include: [
+    { model: models.User},
+  ]
   })
+}
+
+// Get All
+export async function getAll(){
+  return await models.Ballot.findAll({
+    include: [
+    { model: models.User},
+  ]
+})
 }

--- a/api/src/modules/ballots/types.js
+++ b/api/src/modules/ballots/types.js
@@ -1,6 +1,6 @@
 // Imports
 import { GraphQLObjectType, GraphQLString, GraphQLInt , GraphQLList } from 'graphql'
-
+import { UserType } from  '../user/types'
 // User type
 const BallotType = new GraphQLObjectType({
   name: 'ballotType',
@@ -12,6 +12,11 @@ const BallotType = new GraphQLObjectType({
     description: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },
+    userId: { type: GraphQLInt },
+    user: { type: UserType},
+    corepresentative: { type: GraphQLString },
+    ballotNumber: { type: GraphQLInt },
+    meetUpAddress: { type: GraphQLString }
   })
 })
 

--- a/api/src/modules/user/model.js
+++ b/api/src/modules/user/model.js
@@ -27,10 +27,12 @@ module.exports = function(sequelize, DataTypes) {
     ballotDescription: {
       type: DataTypes.TEXT
     },
-    meetUpAddress: {
-      type: DataTypes.STRING
+    step: {
+      type: DataTypes.INTEGER
     }
   })
-
+  User.associate = function(models) {
+    User.hasMany(models.Ballot)
+  }
   return User
 }

--- a/api/src/modules/user/mutations.js
+++ b/api/src/modules/user/mutations.js
@@ -53,10 +53,10 @@ export const updateUser = {
       name: 'email',
       type: GraphQLString
     },
-    // password: {
-    //   name: 'password',
-    //   type: GraphQLString
-    // },
+    password: {
+      name: 'password',
+      type: GraphQLString
+    },
     thirty_days_from: {
       name: 'thirty_days_from',
       type: GraphQLString
@@ -68,6 +68,10 @@ export const updateUser = {
     ballotDescription: {
       name: 'ballotDescription',
       type: GraphQLString
+    },
+    step: {
+      name: 'step',
+      type: GraphQLInt
     }
   },
   resolve: updateUserResolver

--- a/api/src/modules/user/resolvers.js
+++ b/api/src/modules/user/resolvers.js
@@ -49,7 +49,6 @@ export async function login(parentValue, { email, password }) {
         thirty_days_from: userDetails.thirty_days_from,
         ballotTitle: userDetails.ballotTitle,
         ballotDescription: userDetails.ballotDescription,
-        meetUpAddress: userDetails.meetUpAddress
       }
 
       return {
@@ -60,7 +59,7 @@ export async function login(parentValue, { email, password }) {
   }
 }
 // Update User
-export async function updateUserResolver(parentValue, { id, email, thirty_days_from, ballotTitle, ballotDescription }, { auth }) {
+export async function updateUserResolver(parentValue, { id, email, thirty_days_from, ballotTitle, ballotDescription, step, password }, { auth }) {
   if(auth.user && auth.user.id > 0) {
     await models.User.update(
       {
@@ -68,7 +67,9 @@ export async function updateUserResolver(parentValue, { id, email, thirty_days_f
         email,
         thirty_days_from,
         ballotTitle,
-        ballotDescription
+        ballotDescription,
+        step,
+        password
       },
       { where: { id } }
     )

--- a/api/src/modules/user/types.js
+++ b/api/src/modules/user/types.js
@@ -14,8 +14,7 @@ const UserType = new GraphQLObjectType({
     updatedAt: { type: GraphQLString },
     thirty_days_from: { type: GraphQLString },
     ballotTitle: { type: GraphQLString },
-    ballotDescription: { type: GraphQLString },
-    meetUpAddress: { type: GraphQLString }
+    ballotDescription: { type: GraphQLString }
   })
 })
 // User Login type

--- a/api/src/seeders/4-user.js
+++ b/api/src/seeders/4-user.js
@@ -15,7 +15,6 @@ module.exports = {
         ballotDescription: "really cool stuff",
         createdAt: new Date(),
         updatedAt: new Date(),
-        meetUpAddress: "123 3rd street"
       },
       {
         name: 'The User',
@@ -26,7 +25,6 @@ module.exports = {
         ballotDescription: "really cool stuff",
         createdAt: new Date(),
         updatedAt: new Date(),
-        meetUpAddress: "123 3rd street"
       }
     ])
   },

--- a/api/src/seeders/6-ballots.js
+++ b/api/src/seeders/6-ballots.js
@@ -17,7 +17,8 @@ module.exports = {
         description: "this awesome ballot",
         subject: "Everything",
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        userId: 1
       }
     ])
   },


### PR DESCRIPTION
Will update later

Co-Authored-By: Michelle <55991172+foleymichelle9@users.noreply.github.com>
Co-Authored-By: Danny Ramos <57972448+muydanny@users.noreply.github.com>
Co-Authored-By: Mariana Cid <53917266+Mariana-21@users.noreply.github.com>

### Type of change made:

- [X] New feature (non-breaking change which adds functionality)

### Detailed Description
User Table Update:
Added step to table (to keep track of what step they're on)
Removed meetUpAddress and added it to the ballots table
Updated mutations, type, model

Ballot Table Creation:
fields; Type, Subject, Description, createdAt, updatedAt, userId (one to many relationship), corepresentative (if there are more than one representatives for the ballot), ballotNumber (allow null = true), meetUpAddress (updatable)
Created model, mutations, query, resolvers, and types which have all been tested in GraphiQL
### Why is this change required? What problem does it solve?
Because
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Many, Google is the bees knees
### Files modified:
/api/src/migrations
/api/modules/ballots
/api/modules/user
/api/setup
/api/seeders

